### PR TITLE
feat: add skip_docstrings CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ gherkin-formatter [OPTIONS] [FILES_OR_DIRECTORIES...]
     *   `left`: Left-aligns keywords (default).
     *   `right`: Right-aligns keywords based on the longest keyword in the current block, providing a visually structured layout.
 *   `--multi-line-tags`: Formats each tag on a new line, indented under the associated element. Default is single-line formatting where all tags appear on one line.
+*   `--skip-docstrings`: Skip docstrings formatting - useful if using custom code on it
 *   `--dry-run`: Preview the changes that would be made without modifying the actual files. The formatted output (if different) will be printed to the console.
 *   `--check`: Check if files are formatted correctly according to the specified options. No files are changed.
     *   Exits with code `0` if all files are well-formatted.

--- a/gherkin_formatter/formatter.py
+++ b/gherkin_formatter/formatter.py
@@ -129,6 +129,7 @@ def _process_single_file(
             use_tabs=args.use_tabs,
             alignment=args.alignment,
             multi_line_tags=args.multi_line_tags,
+            skip_docstrings=args.skip_docstrings,
         )
         formatted_content: str = formatter.format()
 
@@ -202,6 +203,11 @@ def main() -> None:
         "--multi-line-tags",
         action="store_true",
         help="Format tags over multiple lines (default: single-line).",
+    )
+    parser.add_argument(
+        "--skip-docstrings",
+        action="store_true",
+        help="Do not format docstrings",
     )
     parser.add_argument(
         "--version",

--- a/gherkin_formatter/parser_writer.py
+++ b/gherkin_formatter/parser_writer.py
@@ -73,6 +73,7 @@ class GherkinFormatter:
         use_tabs: bool = False,
         alignment: str = "left",
         multi_line_tags: bool = False,
+        skip_docstrings: bool = False,
     ) -> None:
         """
         Initialize the GherkinFormatter.
@@ -93,6 +94,7 @@ class GherkinFormatter:
         self.use_tabs: bool = use_tabs
         self.alignment: str = alignment
         self.multi_line_tags: bool = multi_line_tags
+        self.skip_docstrings: bool = skip_docstrings
         self.indent_str = "\t" if self.use_tabs else " " * self.tab_width
         self.comments_to_process: list[dict[str, Any]] = sorted(  # type: ignore[misc]
             self.ast.get("comments", []),
@@ -272,6 +274,16 @@ class GherkinFormatter:
         lines.append(self._indent_line(delimiter, current_indent_level))
 
         content: str = docstring_node.get("content", "")
+
+        if self.skip_docstrings:
+            lines.extend(
+                [
+                    self._indent_line(row, current_indent_level) if row.strip() else ""
+                    for row in content.split("\n")
+                ]
+            )
+            lines.append(self._indent_line(delimiter, current_indent_level))
+            return lines
 
         try:
             json_obj: Any = json.loads(content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gherkin-formatter"
-version = "0.1.2"
+version = "0.1.3"
 description = "A command-line tool to format Gherkin .feature files."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_formatter_cli.py
+++ b/tests/test_formatter_cli.py
@@ -676,3 +676,36 @@ def test_cli_check_mode_needs_reformatting_custom_options(tmp_path: Path) -> Non
     )
     assert "needs formatting" in result.stdout
     assert "file(s) that need formatting" in result.stderr
+
+
+def test_cli_skip_docstrings_option(tmp_path: Path) -> None:
+    """
+    Test --skip-docstrings option preserves docstring content as-is.
+
+    :param tmp_path: Pytest fixture for temporary path.
+    :type tmp_path: Path
+    """
+    input_gherkin: str = '''
+Feature: DocString Test
+
+  Scenario: Test with docstring
+    Given a step with a docstring
+      """
+      {
+
+          "a": "This should not be formatted"
+
+
+      }
+      """
+    When another step
+'''.strip()
+
+    result: subprocess.CompletedProcess = run_cli_with_content(
+        ["--skip-docstrings"],
+        input_gherkin,
+        tmp_path,
+    )
+    assert result.returncode == 0
+    formatted_content: str = (tmp_path / "test.feature").read_text(encoding="utf-8")
+    assert formatted_content.strip() == input_gherkin.strip()

--- a/tests/test_formatter_options.py
+++ b/tests/test_formatter_options.py
@@ -72,3 +72,19 @@ def test_format_multi_line_tags_direct() -> None:
     formatted_tags_indent1 = formatter._format_tags(tags_ast, 1)  # noqa: SLF001
     expected_tags_indent1 = ["  @tag1", "  @tag2", "  @long_tag3"]
     assert formatted_tags_indent1 == expected_tags_indent1
+
+
+def test_format_docstring_with_skip_docstrings_enabled() -> None:
+    """Test _format_docstring behavior when skip_docstrings=True."""
+    ast: dict[str, Any] = {"feature": None, "comments": []}
+    formatter = GherkinFormatter(ast, skip_docstrings=True)
+
+    # Test with JSON content that would normally be formatted
+    unformatted_json_content = '{"key": "value",    "nested":    {"array": [1, 2, 3]}}'
+    docstring_node = {"content": unformatted_json_content, "delimiter": '"""'}
+
+    formatted_lines = formatter._format_docstring(docstring_node, 1)  # noqa: SLF001
+
+    # When skip_docstrings=True, content should be preserved as-is
+    expected_lines = ['  """', f"  {unformatted_json_content}", '  """']
+    assert formatted_lines == expected_lines


### PR DESCRIPTION
This option skip formatting the docstrings inside the .feature files.
This may be useful to some use-cases where the docstring contains something not parseable - like code from template engines - and may be misinterpreted.

This also helps as a temporary fix for https://github.com/musthafak/gherkin-formatter/issues/2