### PR TITLE
Fixed invalid yaml output due to wrong indentation

### DIFF
--- a/gherkin_formatter/parser_writer.py
+++ b/gherkin_formatter/parser_writer.py
@@ -333,7 +333,7 @@ class GherkinFormatter:
         ruamel_yaml_instance = YAML()
         ruamel_yaml_instance.indent(
             mapping=self.tab_width,
-            sequence=self.tab_width,
+            sequence=self.tab_width + 2,
             offset=self.tab_width,
         )
         ruamel_yaml_instance.preserve_quotes = True

--- a/tests/test_formatter_elements.py
+++ b/tests/test_formatter_elements.py
@@ -149,6 +149,25 @@ def test_format_docstring_valid_yaml_block_style() -> None:
     actual_output = formatter.format().strip()
     assert actual_output == expected_output
 
+def test_format_docstring_yaml_offset_invalid_output() -> None:
+    yaml_content = "list:\n  - item1:\n    item2:"
+    ast = _get_docstring_feature_ast(yaml_content)
+    formatter = GherkinFormatter(ast, tab_width=2)  # Default tab_width = 2
+    expected_lines = [
+        "Feature: DocString Test",
+        "",
+        "  Scenario: Test Scenario",
+        "    Given a step with a docstring",
+        '      """',
+        "      list:",
+        "        - item1:",
+        "          item2:",
+        '      """',
+    ]
+    expected_output = "\n".join(expected_lines)
+    actual_output = formatter.format().strip()
+    assert actual_output == expected_output
+
 
 def test_format_docstring_valid_yaml_with_tabs_indent() -> None:
     """Test formatting a DocString with valid YAML content using tabs for Gherkin indent."""

--- a/tests/test_formatter_elements.py
+++ b/tests/test_formatter_elements.py
@@ -149,6 +149,7 @@ def test_format_docstring_valid_yaml_block_style() -> None:
     actual_output = formatter.format().strip()
     assert actual_output == expected_output
 
+
 def test_format_docstring_yaml_offset_sequence_indentation() -> None:
     """Test formatting a DocString with valid YAML ensuring valid output."""
     yaml_content = "list:\n  - item1:\n    item2:"

--- a/tests/test_formatter_elements.py
+++ b/tests/test_formatter_elements.py
@@ -149,7 +149,8 @@ def test_format_docstring_valid_yaml_block_style() -> None:
     actual_output = formatter.format().strip()
     assert actual_output == expected_output
 
-def test_format_docstring_yaml_offset_invalid_output() -> None:
+def test_format_docstring_yaml_offset_sequence_indentation() -> None:
+    """Test formatting a DocString with valid YAML ensuring valid output."""
     yaml_content = "list:\n  - item1:\n    item2:"
     ast = _get_docstring_feature_ast(yaml_content)
     formatter = GherkinFormatter(ast, tab_width=2)  # Default tab_width = 2


### PR DESCRIPTION
The formatter produced invalid yaml output in the following case:
```yaml
list:
  - item1
    item2
```
is formatted to
```yaml
list:
  - item1
  item2
```
which is not valid yaml anymore.

> [It is best to always have sequence >= offset + 2 but this is not enforced. Depending on your structure, not following this advice might lead to invalid output.](https://yaml.dev/doc/ruamel.yaml/detail/#Indentation_of_block_sequences)