### PR TITLE
Added options for custom description indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ gherkin-formatter [OPTIONS] [FILES_OR_DIRECTORIES...]
     *   Exits with code `0` if all files are well-formatted.
     *   Exits with code `1` if one or more files would be reformatted or had file-specific processing issues (e.g., parsing errors).
     *   Exits with code `123` if an internal error occurred in the formatter.
+*   `--add-feature-description-indent`: Additional indent for Feature description (default: 1).
+*   `--add-rule-description-indent`: Additional indent for Rule description (default: 1).
+*   `--add-background-description-indent`: Additional indent for Background description (default: 1).
+*   `--add-scenario-description-indent`: Additional indent for Scenario description (default: 1).
+*   `--add-example-description-indent`: Additional indent for Example description (default: 1).
 *   `--version`: Show the program's version number and exit.
 *   `--help`: Show this help message and exit.
 

--- a/gherkin_formatter/formatter.py
+++ b/gherkin_formatter/formatter.py
@@ -129,6 +129,11 @@ def _process_single_file(
             use_tabs=args.use_tabs,
             alignment=args.alignment,
             multi_line_tags=args.multi_line_tags,
+            add_feature_description_indent=args.add_feature_description_indent,
+            add_rule_description_indent=args.add_rule_description_indent,
+            add_background_description_indent=args.add_background_description_indent,
+            add_scenario_description_indent=args.add_scenario_description_indent,
+            add_example_description_indent=args.add_example_description_indent,
         )
         formatted_content: str = formatter.format()
 
@@ -190,6 +195,36 @@ def main() -> None:
         "--use-tabs",
         action="store_true",
         help="Use tabs for indentation. Overrides --tab-width.",
+    )
+    parser.add_argument(
+        "--add-feature-description-indent",
+        type=int,
+        default=1,
+        help="Additional indent for Feature description (default: 1).",
+    )
+    parser.add_argument(
+        "--add-rule-description-indent",
+        type=int,
+        default=1,
+        help="Additional indent for Rule description (default: 1).",
+    )
+    parser.add_argument(
+        "--add-background-description-indent",
+        type=int,
+        default=1,
+        help="Additional indent for Background description (default: 1).",
+    )
+    parser.add_argument(
+        "--add-scenario-description-indent",
+        type=int,
+        default=1,
+        help="Additional indent for Scenario description (default: 1).",
+    )
+    parser.add_argument(
+        "--add-example-description-indent",
+        type=int,
+        default=1,
+        help="Additional indent for Example description (default: 1).",
     )
     parser.add_argument(
         "-a",

--- a/gherkin_formatter/parser_writer.py
+++ b/gherkin_formatter/parser_writer.py
@@ -65,7 +65,7 @@ class GherkinFormatter:
     """
 
     # pylint: disable-next=too-many-arguments,too-many-positional-arguments
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         ast: GherkinDocument | dict[str, Any],
         *,
@@ -73,6 +73,11 @@ class GherkinFormatter:
         use_tabs: bool = False,
         alignment: str = "left",
         multi_line_tags: bool = False,
+        add_feature_description_indent: int = 1,
+        add_rule_description_indent: int = 1,
+        add_background_description_indent: int = 1,
+        add_scenario_description_indent: int = 1,
+        add_example_description_indent: int = 1,
     ) -> None:
         """
         Initialize the GherkinFormatter.
@@ -87,12 +92,32 @@ class GherkinFormatter:
         :type alignment: str
         :param multi_line_tags: Format tags over multiple lines (default: False).
         :type multi_line_tags: bool
+        :param add_feature_description_indent: Additional indent
+            for Feature description (default: 1).
+        :type add_feature_description_indent: int
+        :param add_rule_description_indent: Additional indent
+            for Rule description (default: 1).
+        :type add_rule_description_indent: int
+        :param add_background_description_indent: Additional indent
+            for Background description (default: 1).
+        :type add_background_description_indent: int
+        :param add_scenario_description_indent: Additional indent
+            for Scenario description (default: 1).
+        :type add_scenario_description_indent: int
+        :param add_example_description_indent: Additional indent
+            for Example description (default: 1).
+        :type add_example_description_indent: int
         """
         self.ast: Any = ast
         self.tab_width: int = tab_width
         self.use_tabs: bool = use_tabs
         self.alignment: str = alignment
         self.multi_line_tags: bool = multi_line_tags
+        self.add_feature_description_indent: int = add_feature_description_indent
+        self.add_rule_description_indent: int = add_rule_description_indent
+        self.add_background_description_indent: int = add_background_description_indent
+        self.add_scenario_description_indent: int = add_scenario_description_indent
+        self.add_example_description_indent: int = add_example_description_indent
         self.indent_str = "\t" if self.use_tabs else " " * self.tab_width
         self.comments_to_process: list[dict[str, Any]] = sorted(  # type: ignore[misc]
             self.ast.get("comments", []),
@@ -476,7 +501,7 @@ class GherkinFormatter:
         lines.extend(
             self._format_description(
                 examples_node.get("description"),
-                current_indent_level + 1,
+                current_indent_level + self.add_example_description_indent,
             ),
         )
 
@@ -525,7 +550,7 @@ class GherkinFormatter:
         lines.extend(
             self._format_description(
                 scenario_node.get("description"),
-                current_indent_level + 1,
+                current_indent_level + self.add_scenario_description_indent,
             ),
         )
 
@@ -574,7 +599,7 @@ class GherkinFormatter:
         lines.extend(
             self._format_description(
                 background_node.get("description"),
-                current_indent_level + 1,
+                current_indent_level + self.add_background_description_indent,
             ),
         )
 
@@ -617,7 +642,7 @@ class GherkinFormatter:
         lines.extend(
             self._format_description(
                 rule_node.get("description"),
-                current_indent_level + 1,
+                current_indent_level + self.add_rule_description_indent,
             ),
         )
 
@@ -682,7 +707,10 @@ class GherkinFormatter:
             for line in desc_lines:
                 if line.strip():  # Only indent non-empty description lines
                     lines.append(
-                        self._indent_line(line.strip(), current_indent_level + 1),
+                        self._indent_line(
+                            line.strip(),
+                            current_indent_level + self.add_feature_description_indent,
+                        ),
                     )
                 else:  # Keep empty lines in description as they are, but without indent
                     lines.append("")

--- a/tests/test_formatter_cli.py
+++ b/tests/test_formatter_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import tempfile
+import textwrap
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
@@ -83,6 +84,11 @@ def test_cli_help_output() -> None:
     assert "FILES_OR_DIRECTORIES" in result.stdout
     assert "--tab-width" in result.stdout
     assert "--use-tabs" in result.stdout
+    assert "--add-feature-description-indent" in result.stdout
+    assert "--add-rule-description-indent" in result.stdout
+    assert "--add-background-description-indent" in result.stdout
+    assert "--add-scenario-description-indent" in result.stdout
+    assert "--add-example-description-indent" in result.stdout
     assert "--alignment" in result.stdout
     assert "--multi-line-tags" in result.stdout
     assert "--version" in result.stdout
@@ -676,3 +682,80 @@ def test_cli_check_mode_needs_reformatting_custom_options(tmp_path: Path) -> Non
     )
     assert "needs formatting" in result.stdout
     assert "file(s) that need formatting" in result.stderr
+
+
+def test_cli_formats_single_file_default_description_indent(
+    feature_file_factory: FeatureFileFactory,
+) -> None:
+    """
+    Test formatting a single file with default CLI description indent (1 width).
+
+    :param feature_file_factory: Fixture to create temporary feature files.
+    :type feature_file_factory: FeatureFileFactory
+    """
+    raw_content: str = textwrap.dedent("""\
+    Feature: Some Feature
+    Some Feature Description.
+
+      Background:
+      Some Background Description.
+        Given Foo
+
+      Scenario: Some Scenario
+      Some Scenario Description.
+        Given Foo
+
+      Rule: Some Rule
+      Some Rule Description.
+
+        Scenario Outline: Some Scenario Outline
+        Some Scenario Outline Description.
+          Given Foo
+
+          Examples:
+          Some Example Description.
+            | foo | bar |
+    """)
+    expected_formatted_content: str = textwrap.dedent("""\
+    Feature: Some Feature
+      Some Feature Description.
+
+      Background:
+        Some Background Description.
+        Given Foo
+
+      Scenario: Some Scenario
+        Some Scenario Description.
+        Given Foo
+
+      Rule: Some Rule
+        Some Rule Description.
+
+        Scenario Outline: Some Scenario Outline
+          Some Scenario Outline Description.
+          Given Foo
+
+          Examples:
+            Some Example Description.
+            | foo | bar |
+    """)
+
+    # Call factory with positional arguments: content, name, base_dir
+    feature_file: Path = feature_file_factory(
+        raw_content,
+        "format_me_default.feature",
+        None,
+    )
+
+    result: subprocess.CompletedProcess = subprocess.run(
+        ["python", "-m", "gherkin_formatter.formatter", str(feature_file)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.returncode == 0
+    assert "Reformatted" in result.stdout
+    assert str(feature_file) in result.stdout
+
+    formatted_content_on_disk: str = feature_file.read_text(encoding="utf-8")
+    assert formatted_content_on_disk == expected_formatted_content

--- a/tests/test_formatter_cli.py
+++ b/tests/test_formatter_cli.py
@@ -759,6 +759,8 @@ def test_cli_formats_single_file_default_description_indent(
 
     formatted_content_on_disk: str = feature_file.read_text(encoding="utf-8")
     assert formatted_content_on_disk == expected_formatted_content
+
+
 def test_cli_skip_docstrings_option(tmp_path: Path) -> None:
     """
     Test --skip-docstrings option preserves docstring content as-is.

--- a/tests/test_formatter_elements.py
+++ b/tests/test_formatter_elements.py
@@ -1068,3 +1068,120 @@ def test_format_scenario_with_multiple_steps_and_varying_indentation() -> None:
     expected_output: str = "\n".join(expected_lines)
     actual_output: str = formatter.format().strip()
     assert actual_output == expected_output
+
+
+def test_format_zero_additional_description_indent() -> None:
+    """Test formatting with zero additional description indent."""
+    feature_ast: dict[str, Any] = {
+        "feature": {
+            "keyword": "Feature",
+            "name": "Scenario Fixed Desc Test",
+            "description": "    Feature Description  \n  Line 2.  ",
+            "language": "en",
+            "children": [
+                {
+                    "background": {
+                        "keyword": "Background",
+                        "name": "Setup",
+                        "description": "BG Description  \n  Line 2.  ",
+                        "steps": [{"keyword": "Given ", "text": "bg step"}],
+                    },
+                },
+                {
+                    "scenario": {
+                        "keyword": "Scenario",
+                        "name": "Test",
+                        "description": " Description\n  Line 2.  ",
+                        "steps": [{"keyword": "Given ", "text": "<var>"}],
+                        "tags": [],
+                    },
+                },
+                {
+                    "scenario": {
+                        "keyword": "Scenario Outline",
+                        "name": "SO",
+                        "description": "    SO Description\n  Line 2.  ",
+                        "steps": [{"keyword": "Given ", "text": "<A>"}],
+                        "tags": [],
+                        "examples": [
+                            {
+                                "keyword": "Examples",
+                                "name": "Set 1",
+                                "description": "Examples description.",
+                                "tags": [],
+                                "tableHeader": {"cells": [{"value": "A"}]},
+                                "tableBody": [{"cells": [{"value": "1"}]}],
+                            },
+                        ],
+                    },
+                },
+                {
+                    "rule": {
+                        "keyword": "Rule",
+                        "name": "Tagged Rule",
+                        "description": "Rule Description \n Line 2.",
+                        "tags": [{"name": "@rule_tag"}],
+                        "children": [
+                            {
+                                "scenario": {
+                                    "keyword": "Scenario",
+                                    "name": "S",
+                                    "description": " Description\n  Line 2.  ",
+                                    "steps": [{"keyword": "Given ", "text": "s"}],
+                                    "tags": [],
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+            "tags": [],
+        },
+        "comments": [],
+    }
+    formatter: GherkinFormatter = GherkinFormatter(
+        feature_ast,
+        tab_width=2,
+        add_feature_description_indent=0,
+        add_rule_description_indent=0,
+        add_background_description_indent=0,
+        add_scenario_description_indent=0,
+        add_example_description_indent=0,
+    )
+    expected_lines: list[str] = [
+        "Feature: Scenario Fixed Desc Test",
+        "Feature Description",
+        "Line 2.",
+        "",
+        "  Background: Setup",
+        "  BG Description",
+        "  Line 2.",
+        "    Given bg step",
+        "",
+        "  Scenario: Test",
+        "  Description",
+        "  Line 2.",
+        "    Given <var>",
+        "",
+        "  Scenario Outline: SO",
+        "  SO Description",
+        "  Line 2.",
+        "    Given <A>",
+        "",
+        "    Examples: Set 1",
+        "    Examples description.",
+        "      | A |",
+        "      | 1 |",
+        "",
+        "  Rule: Tagged Rule",
+        "  Rule Description",
+        "  Line 2.",
+        "",
+        "    Scenario: S",
+        "    Description",
+        "    Line 2.",
+        "      Given s",
+    ]
+    expected_output: str = "\n".join(expected_lines)
+    actual_output: str = formatter.format().strip()
+    assert actual_output == expected_output


### PR DESCRIPTION
PyCharm's Gherkin Plugin formats description strings on the same indent level as the Rule, Background, Scenario and Example keyword.

To allow this behavior, added the following CLI options:
- `--add-feature-description-indent`: Additional indent for Feature description (default: 1)
- `--add-rule-description-indent`: Additional indent for Rule description (default: 1)
- `--add-background-description-indent`: Additional indent for Background description (default: 1)
- `--add-scenario-description-indent`: Additional indent for Scenario description (default: 1)
- `--add-example-description-indent`: Additional indent for Example description (default: 1)


