### PR TITLE
Fix pre-commit failures

### DIFF
--- a/gherkin_formatter/parser_writer.py
+++ b/gherkin_formatter/parser_writer.py
@@ -65,7 +65,7 @@ class GherkinFormatter:
     """
 
     # pylint: disable-next=too-many-arguments,too-many-positional-arguments
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         ast: GherkinDocument | dict[str, Any],
         *,

--- a/gherkin_formatter/parser_writer.py
+++ b/gherkin_formatter/parser_writer.py
@@ -88,6 +88,8 @@ class GherkinFormatter:
         :type alignment: str
         :param multi_line_tags: Format tags over multiple lines (default: False).
         :type multi_line_tags: bool
+        :param skip_docstrings: Skip formatting of docstrings (default: False).
+        :type skip_docstrings: bool
         """
         self.ast: Any = ast
         self.tab_width: int = tab_width

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ ignore = [
   "D212",   # multi-line-summary-first-line
   "ANN204", # annotation of __init__()
   "FIX002", # we need to keep TODOs in the code
+  "COM812", # https://docs.astral.sh/ruff/rules/missing-trailing-comma/#formatter-compatibility
 ]
 select = ["ALL"]
 


### PR DESCRIPTION
PR CI failed due to [failing pre-commit hooks](https://github.com/musthafak/gherkin-formatter/actions/runs/26567837538/job/78266974374?pr=5)

- added docstring to fix darglint2  DAR101
- added COM812 to ruff ignore [as recommended](https://docs.astral.sh/ruff/rules/missing-trailing-comma/#formatter-compatibility)
- added noqa: PLR0913 for GherkinFormatter constructor