### PR TITLE
Table cells containing escaped pipes results in malformed feature

### DIFF
--- a/gherkin_formatter/parser_writer.py
+++ b/gherkin_formatter/parser_writer.py
@@ -232,15 +232,18 @@ class GherkinFormatter:
                 self._indent_line("| |", current_indent_level) for _ in table_node_rows
             ]
 
+        def _escape_pipe(val: str) -> str:
+            return val.replace("|", "\\|")
+
         col_widths: list[int] = [0] * num_columns
         for row_data in table_node_rows:
             for i, cell in enumerate(row_data["cells"]):
-                col_widths[i] = max(col_widths[i], len(cell["value"]))
+                col_widths[i] = max(col_widths[i], len(_escape_pipe(cell["value"])))
 
         formatted_lines: list[str] = []
         for row_data in table_node_rows:
             formatted_cells: list[str] = [
-                cell["value"].ljust(col_widths[i])
+                _escape_pipe(cell["value"]).ljust(col_widths[i])
                 for i, cell in enumerate(row_data["cells"])
             ]
             formatted_lines.append(

--- a/tests/test_formatter_structures.py
+++ b/tests/test_formatter_structures.py
@@ -337,8 +337,8 @@ def test_format_datatable_cell_with_pipe() -> None:
         "",
         "  Scenario: Test Scenario",
         "    Given a step with a data table",
-        "      | Header            |",
-        "      | Value | with pipe |",
+        "      | Header             |",
+        "      | Value \\| with pipe |",
     ]
     expected_output = "\n".join(expected_lines)
     actual_output = formatter.format().strip()


### PR DESCRIPTION
Closes https://github.com/musthafak/gherkin-formatter/issues/7

The gherkin parser reads in cells containing escaped pipe symbols and puts them unescaped into the cell values.
When writing these cells back to a file, the pipes need to be escaped again.
